### PR TITLE
📃 Guide developers to the Windows emoji picker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,10 +8,12 @@
 # You may also decide to promote someone else to code owner, for example after
 # an existing owner has a pair programming, or training session. It is the goal
 # that eventually all team members are code owners for the entire repository.
-/.github/CODEOWNERS     @carveco/carveco-development
+/.github/CODEOWNERS          @carveco/carveco-development
 
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence, they will be requested for review when someone
 # opens a pull request.  
 # Order is important; the last matching pattern takes the most precedence.
-*                       @carveco/carveco-development
+*                            @carveco/carveco-development
+
+/docs/commit_messages.md     @timgreen545

--- a/docs/commit_messages.md
+++ b/docs/commit_messages.md
@@ -31,41 +31,41 @@ performance improvement shouldn't change functionality.
 
 
 | Commit type                | Emoji | Emoji picker description          |
-| :------------------------- | :---- | :-------------------------------- |
-| New feature                | ✨     | sparkles                          |
-| Bugfix                     | 🐛     | bug                               |
-| Documentation              | 📃     | page with curl                    |
-| Performance                | 🏇     | horse racing                      |
-| Cosmetic (UI)              | 💄     | lipstick                          |
-| Tests                      | 🚨     | police car light                  |
-| Adding a test              | 🧪     | test tube                         |
-| Make a test pass           | ✅     | check mark button                 |
-| General update             | ⚡     | high voltage (zap)                |
-| Improve code formatting    | 🎨     | artist palette                    |
-| Lint                       | 👕     | t-shirt                           |
-| Refactor code              | 🔨     | hammer                            |
-| Tidy/improve readability   | 🧹     | broom                             |
-| Removing code/files        | 🔥     | fire                              |
-| Continuous Integration     | 👷     | construction worker               |
-| Security                   | 🔒     | locked                            |
-| Translation                | 🌐     | globe with meridians              |
-| Text (UI)                  | 📝     | memo (with pencil)                |
-| Critical hotfix            | 🚑     | ambulance                         |
-| Publish release            | 🚀     | rocket                            |
-| Fixing on Linux            | 🐧     | penguin                           |
-| Add feature flag           | 🏁     | checkered (or chequered) flag     |
-| Work in progress           | 🚧     | construction                      |
-| Analytics or tracking code | 📈     | chart increasing                  |
-| Removing a dependency      | ➖     | minus                             |
-| Adding a dependency        | ➕     | plus                              |
-| Upgrading dependencies     | ⬆️     | up arrow                          |
-| Downgrading dependencies   | ⬇️     | down arrow                        |
-| Docker                     | 🐳     | whale                             |
-| Configuration files        | 🔧     | wrench                            |
-| Bad code / need improv.    | 💩     | pile of poo                       |
-| Reverting changes          | ⏪     | fast reverse button (rewind)      |
-| Accessibility              | ♿     | wheelchair symbol                 |
-| Move/rename                | 🚚     | delivery truck                    |
+| :------------------------- | :---: | :-------------------------------- |
+| New feature                |   ✨   | sparkles                          |
+| Bugfix                     |   🐛   | bug                               |
+| Documentation              |   📃   | page with curl                    |
+| Performance                |   🏇   | horse racing                      |
+| Cosmetic (UI)              |   💄   | lipstick                          |
+| Tests                      |   🚨   | police car light                  |
+| Adding a test              |   🧪   | test tube                         |
+| Make a test pass           |   ✅   | check mark button                 |
+| General update             |   ⚡   | high voltage (zap)                |
+| Improve code formatting    |   🎨   | artist palette                    |
+| Lint                       |   👕   | t-shirt                           |
+| Refactor code              |   🔨   | hammer                            |
+| Tidy/improve readability   |   🧹   | broom                             |
+| Removing code/files        |   🔥   | fire                              |
+| Continuous Integration     |   👷   | construction worker               |
+| Security                   |   🔒   | locked                            |
+| Translation                |   🌐   | globe with meridians              |
+| Text (UI)                  |   📝   | memo (with pencil)                |
+| Critical hotfix            |   🚑   | ambulance                         |
+| Publish release            |   🚀   | rocket                            |
+| Fixing on Linux            |   🐧   | penguin                           |
+| Add feature flag           |   🏁   | checkered (or chequered) flag     |
+| Work in progress           |   🚧   | construction                      |
+| Analytics or tracking code |   📈   | chart increasing                  |
+| Removing a dependency      |   ➖   | minus                             |
+| Adding a dependency        |   ➕   | plus                              |
+| Upgrading dependencies     |   ⬆️   | up arrow                          |
+| Downgrading dependencies   |   ⬇️   | down arrow                        |
+| Docker                     |   🐳   | whale                             |
+| Configuration files        |   🔧   | wrench                            |
+| Bad code / need improv.    |   💩   | pile of poo                       |
+| Reverting changes          |   ⏪   | fast reverse button (rewind)      |
+| Accessibility              |   ♿   | wheelchair symbol                 |
+| Move/rename                |   🚚   | delivery truck                    |
 | Other                      |       | Create a PR to suggest something! |
 
 Based on

--- a/docs/commit_messages.md
+++ b/docs/commit_messages.md
@@ -22,6 +22,9 @@ organisation.
 Commit message titles may begin with an emoji. If they do, the meaning should
 be roughly consistent with other commits by following the chart below.
 
+Use the key combination 🪟+. (windows key and dot) to show the Windows emoji picker
+(works in the major web browsers, code editors, and terminal).
+
 Emoji may compress extra information in a limited space (50 characters) and set
 expectations about what the commit contains. For example, a refactoring or
 performance improvement shouldn't change functionality.
@@ -70,9 +73,6 @@ Based on
 with inspiration from
 [`dannyfritz/commit-message-emoji`](https://github.com/dannyfritz/commit-message-emoji),
 [`gitmoji`](https://gitmoji.carloscuesta.me/) and [`Git-Emoji`](https://babakks.github.io/article/2020/07/03/emojis-in-git-commit-messages.html).
-
-Use the key combination 🪟+. (windows key and dot) to show the Windows emoji picker
-(works in the major web browsers, code editors, and terminal).
 
 ### Examples
 

--- a/docs/commit_messages.md
+++ b/docs/commit_messages.md
@@ -27,42 +27,42 @@ expectations about what the commit contains. For example, a refactoring or
 performance improvement shouldn't change functionality.
 
 
-| Commit type                | Emoji | Equivalent Markdown tag           |
+| Commit type                | Emoji | Emoji picker description          |
 | :------------------------- | :---- | :-------------------------------- |
-| New feature                | ✨     | `:sparkles:`                      |
-| Bugfix                     | 🐛     | `:bug:`                           |
-| Documentation              | 📃     | `:page_with_curl:`                |
-| Performance                | 🏇     | `:horse_racing:`                  |
-| Cosmetic (UI)              | 💄     | `:lipstick:`                      |
-| Tests                      | 🚨     | `:rotating_light:`                |
-| Adding a test              | 🧪     | `:test_tube:`                     |
-| Make a test pass           | ✅     | `:white_check_mark:`              |
-| General update             | ⚡     | `:zap:`                           |
-| Improve code formatting    | 🎨     | `:art:`                           |
-| Lint                       | 👕     | `:shirt:`                         |
-| Refactor code              | 🔨     | `:hammer:`                        |
-| Tidy/improve readability   | 🧹     | `:broom:`                         |
-| Removing code/files        | 🔥     | `:fire:`                          |
-| Continuous Integration     | 👷     | `:construction_worker:`           |
-| Security                   | 🔒     | `:lock:`                          |
-| Translation                | 🌐     | `:globe_with_meridians:`          |
-| Text (UI)                  | 📝     | `:pencil:`                        |
-| Critical hotfix            | 🚑     | `:ambulance:`                     |
-| Publish release            | 🚀     | `:rocket:`                        |
-| Fixing on Linux            | 🐧     | `:penguin:`                       |
-| Add feature flag           | 🏁     | `:checkered_flag:`                |
-| Work in progress           | 🚧     | `:construction:`                  |
-| Analytics or tracking code | 📈     | `:chart_with_upwards_trend:`      |
-| Removing a dependency      | ➖     | `:heavy_minus_sign:`              |
-| Adding a dependency        | ➕     | `:heavy_plus_sign:`               |
-| Upgrading dependencies     | ⬆️     | `:arrow_up:`                      |
-| Downgrading dependencies   | ⬇️     | `:arrow_down:`                    |
-| Docker                     | 🐳     | `:whale:`                         |
-| Configuration files        | 🔧     | `:wrench:`                        |
-| Bad code / need improv.    | 💩     | `:hankey:`                        |
-| Reverting changes          | ⏪     | `:rewind:`                        |
-| Accessibility              | ♿     | `:wheelchair:`                    |
-| Move/rename                | 🚚     | `:truck:`                         |
+| New feature                | ✨     | sparkles                          |
+| Bugfix                     | 🐛     | bug                               |
+| Documentation              | 📃     | page with curl                    |
+| Performance                | 🏇     | horse racing                      |
+| Cosmetic (UI)              | 💄     | lipstick                          |
+| Tests                      | 🚨     | police car light                  |
+| Adding a test              | 🧪     | test tube                         |
+| Make a test pass           | ✅     | check mark button                 |
+| General update             | ⚡     | high voltage (zap)                |
+| Improve code formatting    | 🎨     | artist palette                    |
+| Lint                       | 👕     | t-shirt                           |
+| Refactor code              | 🔨     | hammer                            |
+| Tidy/improve readability   | 🧹     | broom                             |
+| Removing code/files        | 🔥     | fire                              |
+| Continuous Integration     | 👷     | construction worker               |
+| Security                   | 🔒     | locked                            |
+| Translation                | 🌐     | globe with meridians              |
+| Text (UI)                  | 📝     | memo (with pencil)                |
+| Critical hotfix            | 🚑     | ambulance                         |
+| Publish release            | 🚀     | rocket                            |
+| Fixing on Linux            | 🐧     | penguin                           |
+| Add feature flag           | 🏁     | checkered (or chequered) flag     |
+| Work in progress           | 🚧     | construction                      |
+| Analytics or tracking code | 📈     | chart increasing                  |
+| Removing a dependency      | ➖     | minus                             |
+| Adding a dependency        | ➕     | plus                              |
+| Upgrading dependencies     | ⬆️     | up arrow                          |
+| Downgrading dependencies   | ⬇️     | down arrow                        |
+| Docker                     | 🐳     | whale                             |
+| Configuration files        | 🔧     | wrench                            |
+| Bad code / need improv.    | 💩     | pile of poo                       |
+| Reverting changes          | ⏪     | fast reverse button (rewind)      |
+| Accessibility              | ♿     | wheelchair symbol                 |
+| Move/rename                | 🚚     | delivery truck                    |
 | Other                      |       | Create a PR to suggest something! |
 
 Based on

--- a/docs/commit_messages.md
+++ b/docs/commit_messages.md
@@ -27,49 +27,52 @@ expectations about what the commit contains. For example, a refactoring or
 performance improvement shouldn't change functionality.
 
 
-| Commit type                | Emoji                             |
-| :------------------------- | :-------------------------------- |
-| New feature                | ✨ `:sparkles:`                    |
-| Bugfix                     | 🐛 `:bug:`                         |
-| Documentation              | 📃 `:page_with_curl:`              |
-| Performance                | 🏇 `:horse_racing:`                |
-| Cosmetic (UI)              | 💄 `:lipstick:`                    |
-| Tests                      | 🚨 `:rotating_light:`              |
-| Adding a test              | 🧪 `:test_tube:`                   |
-| Make a test pass           | ✅ `:white_check_mark:`            |
-| General update             | ⚡ `:zap:`                         |
-| Improve code formatting    | 🎨 `:art:`                         |
-| Lint                       | 👕 `:shirt:`                       |
-| Refactor code              | 🔨 `:hammer:`                      |
-| Tidy/improve readability   | 🧹 `:broom:`                       |
-| Removing code/files        | 🔥 `:fire:`                        |
-| Continuous Integration     | 👷 `:construction_worker:`         |
-| Security                   | 🔒 `:lock:`                        |
-| Translation                | 🌐 `:globe_with_meridians:`        |
-| Text (UI)                  | 📝 `:pencil:`                      |
-| Critical hotfix            | 🚑 `:ambulance:`                   |
-| Publish release            | 🚀 `:rocket:`                      |
-| Fixing on Linux            | 🐧 `:penguin:`                     |
-| Add feature flag           | 🏁 `:checkered_flag:`              |
-| Work in progress           | 🚧  `:construction:`               |
-| Analytics or tracking code | 📈 `:chart_with_upwards_trend:`    |
-| Removing a dependency      | ➖ `:heavy_minus_sign:`            |
-| Adding a dependency        | ➕ `:heavy_plus_sign:`             |
-| Upgrading dependencies     | ⬆️ `:arrow_up:`                    |
-| Downgrading dependencies   | ⬇️ `:arrow_down:`                  |
-| Docker                     | 🐳 `:whale:`                       |
-| Configuration files        | 🔧 `:wrench:`                      |
-| Bad code / need improv.    | 💩 `:hankey:`                      |
-| Reverting changes          | ⏪ `:rewind:`                      |
-| Accessibility              | ♿ `:wheelchair:`                  |
-| Move/rename                | 🚚 `:truck:`                       |
-| Other                      | Create a PR to suggest something! |
+| Commit type                | Emoji | Equivalent Markdown tag           |
+| :------------------------- | :---- | :-------------------------------- |
+| New feature                | ✨     | `:sparkles:`                      |
+| Bugfix                     | 🐛     | `:bug:`                           |
+| Documentation              | 📃     | `:page_with_curl:`                |
+| Performance                | 🏇     | `:horse_racing:`                  |
+| Cosmetic (UI)              | 💄     | `:lipstick:`                      |
+| Tests                      | 🚨     | `:rotating_light:`                |
+| Adding a test              | 🧪     | `:test_tube:`                     |
+| Make a test pass           | ✅     | `:white_check_mark:`              |
+| General update             | ⚡     | `:zap:`                           |
+| Improve code formatting    | 🎨     | `:art:`                           |
+| Lint                       | 👕     | `:shirt:`                         |
+| Refactor code              | 🔨     | `:hammer:`                        |
+| Tidy/improve readability   | 🧹     | `:broom:`                         |
+| Removing code/files        | 🔥     | `:fire:`                          |
+| Continuous Integration     | 👷     | `:construction_worker:`           |
+| Security                   | 🔒     | `:lock:`                          |
+| Translation                | 🌐     | `:globe_with_meridians:`          |
+| Text (UI)                  | 📝     | `:pencil:`                        |
+| Critical hotfix            | 🚑     | `:ambulance:`                     |
+| Publish release            | 🚀     | `:rocket:`                        |
+| Fixing on Linux            | 🐧     | `:penguin:`                       |
+| Add feature flag           | 🏁     | `:checkered_flag:`                |
+| Work in progress           | 🚧     | `:construction:`                  |
+| Analytics or tracking code | 📈     | `:chart_with_upwards_trend:`      |
+| Removing a dependency      | ➖     | `:heavy_minus_sign:`              |
+| Adding a dependency        | ➕     | `:heavy_plus_sign:`               |
+| Upgrading dependencies     | ⬆️     | `:arrow_up:`                      |
+| Downgrading dependencies   | ⬇️     | `:arrow_down:`                    |
+| Docker                     | 🐳     | `:whale:`                         |
+| Configuration files        | 🔧     | `:wrench:`                        |
+| Bad code / need improv.    | 💩     | `:hankey:`                        |
+| Reverting changes          | ⏪     | `:rewind:`                        |
+| Accessibility              | ♿     | `:wheelchair:`                    |
+| Move/rename                | 🚚     | `:truck:`                         |
+| Other                      |       | Create a PR to suggest something! |
 
 Based on
 [`parmentf/GitCommitEmoji.md`](https://gist.github.com/parmentf/035de27d6ed1dce0b36a),
 with inspiration from
 [`dannyfritz/commit-message-emoji`](https://github.com/dannyfritz/commit-message-emoji),
 [`gitmoji`](https://gitmoji.carloscuesta.me/) and [`Git-Emoji`](https://babakks.github.io/article/2020/07/03/emojis-in-git-commit-messages.html).
+
+Use the key combination 🪟+. (windows key and dot) to show the Windows emoji picker
+(works in the major web browsers, code editors, and terminal).
 
 ### Examples
 


### PR DESCRIPTION
Developers should use actual emojis instead of markdown tags of emojis.

If markdown tags are used they will count as extra characters against the line length guide. e.g.
:chart_with_upwards_trend:
vs
📈

Markdown tags only render correctly on github's website.