### PR TITLE
📃 Update PR template issue link to Linear

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 
 ---
 
-https://carveco.atlassian.net/browse/CD-<ID>
+refs https://linear.app/carveco/issue/<ID>


### PR DESCRIPTION
- Update the issue link in the PR template to point to Linear instead of Jira. 
- Prepend magic word 'refs' to the link so that it gets picked up by Linear and linked to the corresponding issue (https://linear.app/docs/github?tabs=206cad22125a#link-prs)